### PR TITLE
fix: do not open images from lists in lightbox if corresponding plugin settings says not to do it

### DIFF
--- a/views/default/object/image/summary.php
+++ b/views/default/object/image/summary.php
@@ -9,12 +9,12 @@
  */
 
 $image = elgg_extract('entity', $vars);
-$icon_options = array(
-	'link_class' => 'elgg-lightbox',
-);
+$icon_options = array();
+
 if ('yes' == elgg_get_plugin_setting('use_popup_lists', 'tidypics_plus'))
 {
 	$icon_options['href'] = 'ajax/view/tidypics/image_popup?guid=' . $image->guid;
+	$icon_options['link_class'] = 'elgg-lightbox';
 	$icon_options['data-colorbox-opts'] = json_encode([
 		'height' => '95%',
 		'width' => '95%',


### PR DESCRIPTION
A lightbox opened even with the plugin setting set to "no lightbox". But the image was not displayed then. Now the full view of the image will work the old way if the setting is set to "no lightbox".
